### PR TITLE
Fix mt-index string placement to avoid invalid jumps

### DIFF
--- a/mt-index.asm
+++ b/mt-index.asm
@@ -431,7 +431,7 @@ TTY_WAIT,
         IOT 6046                / Transmit character
         JMP I PUTCHR_PTR
 
-        *0600
+        *1000
 TITLE_MSG,
         0115    / M
         0101    / A
@@ -549,7 +549,7 @@ FORMAT_BUF,
         0
         0
 
-        *0740               / Keep CHARMAP away from buffers
+        *1200               / Keep CHARMAP away from buffers
 CHARMAP,
         0040
         0101


### PR DESCRIPTION
## Summary
- relocate the mt-index title/label/format string block to start at 0o1000 so it no longer overwrites the helper subroutines
- move the CHARMAP table to 0o1200 to keep the data buffers contiguous and away from the relocated strings

## Testing
- python3 tools/pdp8_asm.py mt-index.asm mt-index.srec
- Manual: ./monitor (read mt-index.srec, ran c 2000 repeatedly to confirm execution stays inside the subroutines)


------
https://chatgpt.com/codex/tasks/task_e_6902ad6be3948333983f135b6c357307